### PR TITLE
Fix requirments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ scikit-learn>=0.24.1
 scipy>=1.6.0
 seaborn>=0.11.1
 six>=1.15.0
-sklearn>=0.0
 smart-open>=4.1.2
 snowballstemmer>=2.1.0
 Sphinx>=3.4.3


### PR DESCRIPTION
## Description
* The requirements.txt file previously included sklearn, which is a deprecated alias for the scikit-learn package. This caused installation errors when using pip, as the sklearn package is no longer maintained and generates an error during dependency resolution.

This PR removes sklearn from the requirements file to resolve this issue.

## Error Details
The following error was encountered during installation:
```
Collecting sklearn>=0.0 (from autobotlib)
  Using cached sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

## Changes Made
Removed sklearn from the requirements.txt.

## Impact
This change ensures smooth installation of dependencies and resolves compatibility issues for new installations.