### PR TITLE
Version Bump to Py 11. 

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip;
-        pip install autobotlib;
+        pip install .;
     - name: Analysing the code with pylint
       run: |
         bash cli_example.sh;

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -9,16 +9,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip;
         pip install autobotlib;
     - name: Analysing the code with pylint
       run: |
-        python -m nltk.downloader stopwords;python -m nltk.downloader punkt;
-        python -m nltk.downloader averaged_perceptron_tagger;
         bash cli_example.sh;

--- a/.github/workflows/core-install.yml
+++ b/.github/workflows/core-install.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -33,6 +33,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python -m nltk.downloader stopwords;python -m nltk.downloader punkt;
-        python -m nltk.downloader averaged_perceptron_tagger;
         cd tests; py.test;

--- a/.github/workflows/core-install.yml
+++ b/.github/workflows/core-install.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        pip install autobotlib
+        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,4 @@
-name: Py 3.9
+name: Py 3.11
 
 on: [push]
 
@@ -9,11 +9,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
         python-version: 3.11
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install autobotlib
+        pip install .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,171 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc

--- a/autoBOTLib/__init__.py
+++ b/autoBOTLib/__init__.py
@@ -11,6 +11,11 @@ from autoBOTLib.optimization.optimization_feature_constructors import *
 from autoBOTLib.optimization.optimization_engine import *
 from autoBOTLib.misc.misc_helpers import *
 
+import nltk
+nltk.download('stopwords')  
+nltk.download('punkt_tab')
+nltk.download('averaged_perceptron_tagger_eng')
+
 import os
 import logging
 

--- a/autoBOTLib/features/features_concepts.py
+++ b/autoBOTLib/features/features_concepts.py
@@ -265,7 +265,7 @@ if __name__ == "__main__":
     labels = example_text['label']
     rex = ConceptFeatures(knowledge_graph="./memory")
     m = rex.fit_transform(text)
-    fnames = rexget_feature_names_out()
+    fnames = rex.get_feature_names_out()
 
     m = m.todense()
     dataframe = pd.DataFrame(m)

--- a/autoBOTLib/features/features_concepts.py
+++ b/autoBOTLib/features/features_concepts.py
@@ -237,9 +237,9 @@ class ConceptFeatures:
             text_vector = self.get_propositionalized_rep(text_vector)
         return self.concept_vectorizer.transform(text_vector)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
 
-        return self.concept_vectorizer.get_feature_names()
+        return self.concept_vectorizer.get_feature_names_out()
 
     def fit_transform(self, text_vector, b=None):
         """
@@ -265,7 +265,7 @@ if __name__ == "__main__":
     labels = example_text['label']
     rex = ConceptFeatures(knowledge_graph="./memory")
     m = rex.fit_transform(text)
-    fnames = rex.get_feature_names()
+    fnames = rexget_feature_names_out()
 
     m = m.todense()
     dataframe = pd.DataFrame(m)

--- a/autoBOTLib/features/features_contextual.py
+++ b/autoBOTLib/features/features_contextual.py
@@ -81,7 +81,7 @@ class ContextualDocs:
         """
         return self.transform(documents)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
         """
         :param fnames: Feature names (custom api artefact)
         """

--- a/autoBOTLib/features/features_document_graph.py
+++ b/autoBOTLib/features/features_document_graph.py
@@ -113,7 +113,7 @@ class RelationalDocs:
 
         self.core_documents = t_tokens
         self.G = self.get_graph(nlist, len(text_list))
-        G = nx.to_scipy_sparse_matrix(self.G,
+        G = nx.to_scipy_sparse_array(self.G,
                                       nodelist=list(range(len(text_list))))
 
         if self.verbose:

--- a/autoBOTLib/features/features_document_graph.py
+++ b/autoBOTLib/features/features_document_graph.py
@@ -181,7 +181,7 @@ class RelationalDocs:
         self.fit(documents)
         return self.transform(documents)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
         return list(["dim_" + str(x) for x in range(self.ndim)])
 
     def get_graph(self, wspace, ltl):

--- a/autoBOTLib/features/features_images.py
+++ b/autoBOTLib/features/features_images.py
@@ -80,7 +80,7 @@ class ImageEmbeddingTransformer:
         """
         return self.transform(documents)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
         """
         :param fnames: Feature names (custom api artefact)
         """

--- a/autoBOTLib/features/features_keyword.py
+++ b/autoBOTLib/features/features_keyword.py
@@ -121,9 +121,9 @@ class KeywordFeatures:
 
         return self.keyword_vectorizer.transform(text_vector)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
 
-        return self.keyword_vectorizer.get_feature_names()
+        return self.keyword_vectorizer.get_feature_names_out()
 
     def fit_transform(self, text_vector, b=None):
         """
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     rex = KeywordFeatures(targets=labels, max_features=512)
     rex.fit(text)
     m = rex.transform(text)
-    feature_names = rex.get_feature_names()
+    feature_names = rex.get_feature_names_out()
 
     m = m.todense()
     dfx = pd.DataFrame(m)

--- a/autoBOTLib/features/features_sentence_embeddings.py
+++ b/autoBOTLib/features/features_sentence_embeddings.py
@@ -92,7 +92,7 @@ class documentEmbedder:
 
         return sparse.csr_matrix(final_matrix)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
 
         return [str(x) + "_" + str(self.dm) for x in list(range(self.ndim))]
 

--- a/autoBOTLib/features/features_token_relations.py
+++ b/autoBOTLib/features/features_token_relations.py
@@ -181,7 +181,7 @@ class relationExtractor:
                 if enx in sorted_correlations
             ]
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
         """
         Return exact feature names.
         """

--- a/autoBOTLib/features/features_topic.py
+++ b/autoBOTLib/features/features_topic.py
@@ -94,7 +94,7 @@ class TopicDocs:
         self.fit(documents)
         return self.transform(documents)
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
         """
         Get feature names.
         """

--- a/autoBOTLib/learning/hyperparameter_configurations.py
+++ b/autoBOTLib/learning/hyperparameter_configurations.py
@@ -12,14 +12,14 @@ torch_sparse_nn_ff_basic = {
 }
 
 scikit_default = {
-    "loss": ["hinge", "log"],
+    "loss": ["hinge", "log_loss"],
     "penalty": ["elasticnet"],
     "alpha": [0.01, 0.001, 0.0001],
     "l1_ratio": [0, 0.1, 0.5, 0.9]
 }
 
 scikit_intense = {
-    "loss": ["log"],
+    "loss": ["log_loss"],
     "penalty": ["elasticnet"],
     "power_t": [0.1, 0.2, 0.3, 0.4, 0.5],
     "class_weight": ["balanced"],
@@ -29,7 +29,7 @@ scikit_intense = {
 }
 
 scikit_intense_final = {
-    "loss": ["hinge", "log", "modified_huber"],
+    "loss": ["hinge", "log_loss", "modified_huber"],
     "penalty": ["elasticnet"],
     "power_t": np.arange(0.05, 0.5, 0.05).tolist(),
     "class_weight": ["balanced"],
@@ -39,7 +39,7 @@ scikit_intense_final = {
 }
 
 scikit_generic_final = {
-    "loss": ["hinge", "log", "modified_huber"],
+    "loss": ["hinge", "log_loss", "modified_huber"],
     "penalty": ["elasticnet"],
     "power_t": [0.1, 0.2, 0.3, 0.4, 0.5],
     "class_weight": ["balanced"],
@@ -48,9 +48,9 @@ scikit_generic_final = {
     "l1_ratio": [0, 0.2, 0.4, 0.5, 0.6, 0.8, 1]
 }
 
-scikit_mini_l1 = {"loss": ["log"], "penalty": ["l1"]}
+scikit_mini_l1 = {"loss": ["log_loss"], "penalty": ["l1"]}
 
-scikit_mini_l2 = {"loss": ["log"], "penalty": ["l2"]}
+scikit_mini_l2 = {"loss": ["log_loss"], "penalty": ["l2"]}
 
 scikit_knn = {
     "n_neighbors": list(range(1, 64, 1)),

--- a/autoBOTLib/optimization/optimization_engine.py
+++ b/autoBOTLib/optimization/optimization_engine.py
@@ -1290,12 +1290,12 @@ space ..")
         current_fnum = 0
         for transformer in self.vectorizer.named_steps[
                 'union'].transformer_list:
-            features = transformer[1].steps[1][1].get_feature_names()
+            features = transformer[1].steps[1][1].get_feature_names_out()
             self.feature_subspaces.append(
                 self.train_feature_space[:, current_fnum:(current_fnum +
                                                           len(features))])
             current_fnum += len(features)
-            self.all_feature_names += features
+            self.all_feature_names += list(features)
             num_feat = len(features)
             for f in features:
                 self.global_feature_name_hash[f] = transformer[0]

--- a/autoBOTLib/optimization/optimization_feature_constructors.py
+++ b/autoBOTLib/optimization/optimization_feature_constructors.py
@@ -296,7 +296,7 @@ class FeaturePrunner:
         print(input_data.shape)
         return input_data
 
-    def get_feature_names(self):
+    def get_feature_names_out(self):
 
         pass
 
@@ -327,7 +327,7 @@ def get_subset(indice_list, data_matrix, vectorizer):
     feature_subspaces = []
     for num_feat, transformer in zip(
             indice_list, vectorizer.named_steps['union'].transformer_list):
-        features = transformer[1].steps[1][1].get_feature_names()
+        features = transformer[1].steps[1][1].get_feature_names_out()
         if num_feat <= len(features):
             subset = data_matrix[:,
                                  current_fnum:(current_fnum +

--- a/examples/generate_embedding.py
+++ b/examples/generate_embedding.py
@@ -17,7 +17,7 @@ def run():
     all_feature_names = []
     for transformer in autoBOTLibObj.vectorizer.named_steps[
             'union'].transformer_list:
-        features = transformer[1].steps[1][1].get_feature_names()
+        features = transformer[1].steps[1][1].get_feature_names_out()
         all_feature_names += features
 
     assert input_instance_embedding.shape[1] == len(all_feature_names)

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ wget>=3.2
 yapf>=0.30.0
 torch>=1.10.0
 tabulate>=0.8.9
+sentence_transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ scikit-learn>=0.24.1
 scipy>=1.6.0
 seaborn>=0.11.1
 six>=1.15.0
-sklearn>=0.0
 smart-open>=4.1.2
 snowballstemmer>=2.1.0
 Sphinx>=3.4.3

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,38 @@
 from os import path
 from setuptools import setup, find_packages
-
+from setuptools.command.install import install
+import subprocess
+import sys
 
 def parse_requirements(file):
     required_packages = []
     with open(path.join(path.dirname(__file__), file)) as req_file:
         for line in req_file:
-            required_packages.append(line.strip())
+            # Exclude any comments or empty lines
+            line = line.strip()
+            if line and not line.startswith("#"):
+                required_packages.append(line)
     return required_packages
 
+class PostInstallCommand(install):
+    """Post-installation for downloading NLTK resources."""
+    def run(self):
+        install.run(self)
+        
+        try:
+            import nltk
+        except ImportError:
+            print("NLTK is not installed. Installing NLTK...")
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "nltk"])
+            import nltk        
+        try:
+            print("Downloading NLTK 'stopwords' resource...")
+            for lib in ['stopwords', 'punkt_tab', 'averaged_perceptron_tagger_eng']:
+                subprocess.check_call([sys.executable, "-m", "nltk.downloader", lib])
+                print(f"NLTK {lib} downloaded successfully.")
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to download NLTK 'stopwords': {e}")
+            sys.exit(1)  # Exit with error code
 
 long_description = """
 autoBOT is an AutoML system for text classification with an emphasis on explainability.
@@ -17,19 +41,25 @@ for a given task, automatically.
 """
 
 packages = [x for x in find_packages() if x != "test"]
-setup(name='autoBOTLib',
-      version='1.19',
-      description="AutoBOT: Explainable AutoML for texts",
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      url='https://github.com/skblaz/autobot',
-      author='Blaž Škrlj',
-      author_email='blaz.skrlj@ijs.si',
-      license='bsd-3-clause-clear',
-      entry_points={
-          'console_scripts': ['autobot-cli = autoBOTLib.__main__:main']
-      },
-      packages=packages,
-      zip_safe=False,
-      include_package_data=True,
-      install_requires=parse_requirements("requirements.txt"))
+
+setup(
+    name='autoBOTLib',
+    version='1.19',
+    description="AutoBOT: Explainable AutoML for texts",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url='https://github.com/skblaz/autobot',
+    author='Blaž Škrlj',
+    author_email='blaz.skrlj@ijs.si',
+    license='bsd-3-clause-clear',
+    entry_points={
+        'console_scripts': ['autobot-cli = autoBOTLib.__main__:main']
+    },
+    packages=packages,
+    zip_safe=False,
+    include_package_data=True,
+    install_requires=parse_requirements("requirements.txt"),  # Ensure nltk is included here
+    cmdclass={
+        'install': PostInstallCommand,
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,5 @@ setup(
     packages=packages,
     zip_safe=False,
     include_package_data=True,
-    install_requires=parse_requirements("requirements.txt"),  # Ensure nltk is included here
-    cmdclass={
-        'install': PostInstallCommand,
-    }
+    install_requires=parse_requirements("requirements.txt")
 )


### PR DESCRIPTION
Previous Issues:

* NLTK package installation was left for the user to manage manually.
* sentence-transformers was missing from the requirements.txt file.
* Code relied on deprecated sklearn imports, which are no longer supported as of December 2023.

Improvements in This PR:
* Updated the codebase to align with Python 3.11.
* Added sentence-transformers to the requirements.txt file for seamless installation.
* Fixed NLTK package installation to ensure automatic setup.
* Replaced deprecated sklearn imports with supported alternatives.

This update streamlines the installation process and ensures compatibility with the latest Python version.